### PR TITLE
Add function to modelFactory to clear the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,56 @@
-model-factory
-=============
-
-#### Owners: Matt Bilyeu
+# model-factory
 
 A tool for building RESTful models for AngularJS
 
-### Developing
+## Developing
+
 Install dependencies:
+
 ```bash
 npm install
 bower install
 ```
 
 Build:
+
 ```bash
 grunt build
 ```
 
 Watch and run unit tests:
+
 ```bash
 grunt dev
 ```
 
-#### TODO
+### TODO
+
 - docs
 - examples
-- add directives to handle supressing model changes from the view to the model
+- add directives to handle suppressing model changes from the view to the model
 - suggestions?
 
-### Design
-This is a simple model factory inspired by angular's [$resource](http://docs.angularjs.org/api/ngResource/service/$resource) and built on top of [jmdobry's](https://github.com/jmdobry) awesome [angular-cache](https://github.com/jmdobry/angular-cache).
+## Design
 
-The model factory builds simple resources that implement REST/CRUD functions with the help of angular-cache. The model-factory creates a single point of truth--all references to an instance point to the same object in memory no matter how many requests you make. This cuts down on memory usage and ensures that the model state is identical across all instances of the model in your controllers. The model-factory also decreases time to render by returning a cached value instead of making multiple requests.
+This is a simple model factory inspired by angular's
+[$resource](http://docs.angularjs.org/api/ngResource/service/$resource) and
+built on top of [jmdobry's](https://github.com/jmdobry) awesome
+[angular-cache](https://github.com/jmdobry/angular-cache).
 
-#### CAVEAT!
-Using angular's two-way binding can lead to unforeseen consequences because all references to a model point to the same object in memory. Let's say a model is bound to an input using ng-model and displayed somewhere else on the page. Editing the input will cause the the other value to update immediately. The server instance of the model will only be updated by calling the model-factory's create or save call. Make sure to keep this in mind while using the model-factory in your app.  (visual aids to come).
+The model factory builds simple resources that implement REST/CRUD functions
+with the help of angular-cache. The model-factory creates a single point of
+truth--all references to an instance point to the same object in memory no
+matter how many requests you make. This cuts down on memory usage and ensures
+that the model state is identical across all instances of the model in your
+controllers. The model-factory also decreases time to render by returning a
+cached value instead of making multiple requests.
+
+### CAVEAT
+
+Using angular's two-way binding can lead to unforeseen consequences because all
+references to a model point to the same object in memory. Let's say a model is
+bound to an input using ng-model and displayed somewhere else on the page.
+Editing the input will cause the other value to update immediately. The server
+instance of the model will only be updated by calling the model-factory's
+create or save call. Make sure to keep this in mind while using the
+model-factory in your app.  (visual aids to come).

--- a/dist/model-factory.js
+++ b/dist/model-factory.js
@@ -361,6 +361,23 @@ angular.module('rjmetrics.model-factory').factory("modelFactory", [
           });
         };
 
+        Model.clearCache = function(ids) {
+          var id, _i, _len, _results;
+          if (ids == null) {
+            ids = [];
+          }
+          if (ids && ids.length > 0) {
+            _results = [];
+            for (_i = 0, _len = ids.length; _i < _len; _i++) {
+              id = ids[_i];
+              _results.push(_modelCache.remove("" + id));
+            }
+            return _results;
+          } else {
+            return _modelCache.removeAll();
+          }
+        };
+
         Model.prototype.$get = function(forceGet, httpOptions) {
           if (forceGet == null) {
             forceGet = false;

--- a/src/modelFactory.coffee
+++ b/src/modelFactory.coffee
@@ -267,6 +267,13 @@ angular.module('rjmetrics.model-factory').factory("modelFactory", [
           , (errorResponse) ->
             return $q.reject(errorResponse)
 
+        @clearCache: (ids = []) =>
+          if ids and ids.length > 0
+            for id in ids
+              _modelCache.remove "#{id}"
+          else
+            _modelCache.removeAll()
+
         # instance methods that you can call on an instantiated model
         # instead of using the static methods. They call the static
         # methods with the correct data.

--- a/test/modelFactorySpec.coffee
+++ b/test/modelFactorySpec.coffee
@@ -672,3 +672,34 @@ describe 'Model Factory', ->
 
     expect(queryResult2).toBe(queryResult)
 
+  it "should clear cache when asked and refetch from backend", ->
+    Model = modelFactory(modelUrl)
+    executeInner = ->
+      httpBackend.expectGET(new RegExp("#{modelUrl}/1"))
+      .respond 200, modelList[0]
+      aModel = null
+      Model.get(1).then (m) -> aModel = m
+      httpBackend.flush()
+      expect(aModel instanceof Model).toBeTruthy()
+    executeInner()
+    Model.clearCache()
+    executeInner()
+
+  it "should allow clearing cache for specific items", ->
+    Model = modelFactory(modelUrl)
+    executeInner = (id) ->
+      httpBackend.expectGET(new RegExp("#{modelUrl}/#{id}"))
+      .respond 200, modelList[id - 1]
+      aModel = null
+      Model.get(id).then (m) -> aModel = m
+      httpBackend.flush()
+      expect(aModel instanceof Model).toBeTruthy()
+      return aModel
+    executeInner(1)
+    model2 = executeInner(2)
+    Model.clearCache([1])
+    executeInner(1)
+    model2_theSecond = null
+    model2.$get().then (m) -> model2_theSecond = m
+    rootScope.$apply()
+    expect(model2_theSecond).toBe(model2)


### PR DESCRIPTION
Motivation
----------

Sometimes you just want to clear the cache. An example is when you call a
route that updates resources, but you do this outside of the Model class
you have created.

This adds a function to clear either the entire cache or specific IDs from
the cache.

Testing
-------

- Just left this to the unit tests