### PR TITLE
make package.json compatible with commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "model-factory",
   "version": "1.0.0",
+  "main": "dist/model-factory.js",
   "description": "A tool for building RESTful models for AngularJS",
   "directories": {
     "test": "test"


### PR DESCRIPTION
Allows for using `require('model-factory')`, when installing via npm.