### PR TITLE
Add circleci 2.0 Config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,2 @@
+# Config Translation Error
+# Could not find stored inference data.  Please run a build and try again.


### PR DESCRIPTION
### Motivation

Circleci is requiring an update to 2.0 by the end of the month

### API changes

N/A

### Implementation Notes

Circleci provides an API endpoint for conversion purposes. In the interest of getting all repos on 2.0 by the deadline, config files that work without further customizations will be added as-is, and updated in the future. In other words, there may be some things we can do to make this faster or more efficient in the future, but for now, it works.

We are also leaving the 1.0 config file intact for now, with the intention of having builds run against both 1.0 and 2.0 until the deadline. This should give us some live data to ensure we're getting the same results from both 1.0 and 2.0.

### Functional Tests

Build ran twice without issues, results are consistent with 1.0
https://circleci.com/gh/RJMetrics/model-factory/50
https://circleci.com/gh/RJMetrics/model-factory/50

### Regression Tests

Leaving 1.0 and 2.0 running will serve as regression, ensuring we get the same pass/fail results for each build.

